### PR TITLE
Consolidate __pycache__ pattern in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
 .idea/*
 Pipfile
 Pipfile.lock
-controller/__pycache__/__init__.cpython-38.pyc
-controller/v1/__pycache__/__init__.cpython-38.pyc
-controller/v1/__pycache__/model.cpython-38.pyc
-controller/v1/__pycache__/root.cpython-38.pyc
-controllers/__pycache__/__init__.cpython-310.pyc
 controllers/database.db
 .env
+__pycache__


### PR DESCRIPTION
This will help declutter our commits with unnecessary cache files